### PR TITLE
Small fixes to Mixin static accessors

### DIFF
--- a/src/main/java/bettercommandblockui/mixin/AbstractCommandBlockScreenAccessor.java
+++ b/src/main/java/bettercommandblockui/mixin/AbstractCommandBlockScreenAccessor.java
@@ -1,6 +1,5 @@
 package bettercommandblockui.mixin;
 
-import com.mojang.brigadier.Command;
 import net.minecraft.client.gui.screen.ChatInputSuggestor;
 import net.minecraft.client.gui.screen.ingame.AbstractCommandBlockScreen;
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,8 +12,8 @@ public interface AbstractCommandBlockScreenAccessor {
     ChatInputSuggestor getCommandSuggestor();
 
     @Accessor("commandSuggestor")
-    public void setCommandSuggestor(ChatInputSuggestor suggestor);
+    void setCommandSuggestor(ChatInputSuggestor suggestor);
 
     @Invoker("onCommandChanged")
-    public void invokeOnCommandChanged(String text);
+    void invokeOnCommandChanged(String text);
 }

--- a/src/main/java/bettercommandblockui/mixin/CommandSuggestorAccessor.java
+++ b/src/main/java/bettercommandblockui/mixin/CommandSuggestorAccessor.java
@@ -26,13 +26,19 @@ public interface CommandSuggestorAccessor{
     List<OrderedText> getMessages();
 
     @Accessor
-    List<Style> getHIGHLIGHT_STYLES();
+    static List<Style> getHIGHLIGHT_STYLES() {
+        throw new AssertionError();
+    }
 
     @Accessor
-    Style getINFO_STYLE();
+    static Style getINFO_STYLE() {
+        throw new AssertionError();
+    }
 
     @Accessor
-    Style getERROR_STYLE();
+    static Style getERROR_STYLE() {
+        throw new AssertionError();
+    }
 
     @Accessor
     Screen getOwner();

--- a/src/main/java/bettercommandblockui/mixin/ServerPlayerEntityAccessor.java
+++ b/src/main/java/bettercommandblockui/mixin/ServerPlayerEntityAccessor.java
@@ -8,5 +8,5 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 @Mixin(ServerPlayerEntity.class)
 public interface ServerPlayerEntityAccessor {
     @Accessor
-    public ServerPlayNetworkHandler getNetworkHandler();
+    ServerPlayNetworkHandler getNetworkHandler();
 }

--- a/src/main/java/bettercommandblockui/mixin/TextFieldWidgetAccessor.java
+++ b/src/main/java/bettercommandblockui/mixin/TextFieldWidgetAccessor.java
@@ -63,7 +63,9 @@ public interface TextFieldWidgetAccessor {
     String getSuggestion();
 
     @Accessor
-    String getHORIZONTAL_CURSOR();
+    static String getHORIZONTAL_CURSOR() {
+        throw new AssertionError();
+    }
 
     @Accessor
     Predicate<String> getTextPredicate();

--- a/src/main/java/bettercommandblockui/mixin/TextRendererAccessor.java
+++ b/src/main/java/bettercommandblockui/mixin/TextRendererAccessor.java
@@ -8,5 +8,5 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 @Mixin(TextRenderer.class)
 public interface TextRendererAccessor{
     @Accessor
-    public TextHandler getHandler();
+    TextHandler getHandler();
 }


### PR DESCRIPTION
This is a small fixes for accessing static fields in the Mixin which it suppress the warning logs.