### PR TITLE
Fix crash when trying to launch on Quilt

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,6 @@
 
   "depends": {
     "fabricloader": ">=0.7.4",
-    "fabric": "*",
     "minecraft": ">=1.20.3"
   },
   "suggests": {


### PR DESCRIPTION
The application page on modrinth.com says that this mod supports Quilt, however, when you try to launch the mod on Quilt, the launch of the game [crashes](https://mclo.gs/1bqmKeH) with the following error:

`BetterCommandBlockUI requires any version of fabric, which is missing!`

This error occurs because in the `fabric.mod.json` file specifies a dependency on `fabric` of any version. It is impossible to satisfy such a dependency when loading a mod using Quilt. However, when removing such a dependency from a file, everything works without problems. I suggest removing the `fabric` dependency from the `fabric.mod.json` file